### PR TITLE
canvasのメディアクエリを修正し、フルスクリーン表示時の幅を100%に設定

### DIFF
--- a/app/style.css
+++ b/app/style.css
@@ -14,8 +14,8 @@ canvas {
 	}
 }
 
-@media (max-width: 640px) {
+@media (max-width: 640px) and (not (display-mode: fullscreen)) {
 	canvas {
-		height: 100%;
+		width: 100%;
 	}
 }

--- a/app/style.css
+++ b/app/style.css
@@ -16,6 +16,6 @@ canvas {
 
 @media (max-width: 640px) {
 	canvas {
-		width: 100%;
+		height: 100%;
 	}
 }


### PR DESCRIPTION
## 概要

canvasのメディアクエリを修正し、フルスクリーン表示時の幅を100%に設定します。